### PR TITLE
Update rubocop and rubocop-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2021-12-20
+
+### Changed
+
+- Update rubocop to 1.23.0
+- Update rubocop-rails to 2.12.4
+- Disable new cops that are pending approval
+
 ## [0.6.1] - 2021-08-02
 
 ### Changed

--- a/default.yml
+++ b/default.yml
@@ -2,7 +2,7 @@ require: rubocop-rails
 
 # Common configuration.
 AllCops:
-  NewCops: enable
+  NewCops: disable
   TargetRubyVersion: 2.6
   Exclude:
     - !ruby/regexp /.*solano.*\.rb$/

--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.6.1'.freeze
+    VERSION = '0.6.2'.freeze
   end
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 1.18.4'
-  spec.add_dependency 'rubocop-rails', '~> 2.11.3'
+  spec.add_dependency 'rubocop', '~> 1.23.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.12.4'
 
   spec.add_dependency 'rubocop-rake', '~> 0.5.1'
   spec.add_dependency 'rubocop-rspec', '~> 2.2.0'


### PR DESCRIPTION
**Description:**  Update rubocop gems to latest versions, also disable newcops that are pending approval to avoid unnecessary changes.
Review: @icariohealth/developers 